### PR TITLE
update chainbridge docs

### DIFF
--- a/bridges/chainbridge.md
+++ b/bridges/chainbridge.md
@@ -15,7 +15,7 @@ ChainBridge is a modular, multi-directional bridge to interact with multiple net
 
 At a high-level, ChainBridge is a message-passing protocol. A set of relayers are constantly looking for events, in either side of the bridge, which trigger a set of actions. Once a triggering event is noted, a set of relayers vote to execute the instructions (included in the event) in the chain on the other side of the bridge.
 
-For example, the bridge can be used to transfer ERC-20 or ERC-721 natively . A set of handler contracts are pre-configured to handle both token standards. At its core, the token transfer mechanism works with a lock-mint, burn-unlock mechanism. First tokens are locked in the source chain, and an event is emitted, which is listened to by the relayers. Then, they vote and (if approved) execute the mint function, giving the same amount of tokens locked in the target chain to the corresponding address.
+For example, the bridge can be used to transfer ERC-20 or ERC-721 natively. A set of handler contracts are pre-configured to handle both token standards. At its core, the token transfer mechanism works with a lock-mint, burn-unlock mechanism. First tokens are locked in the source chain, and an event is emitted, which is listened to by the relayers. Then, they vote and (if approved) execute the mint function, giving the same amount of tokens locked in the target chain to the corresponding address.
 
 You can read more about ChainBridge (and ChainSafe) in the following links:
 

--- a/bridges/chainbridge.md
+++ b/bridges/chainbridge.md
@@ -47,7 +47,7 @@ You can find all the contract's addresses that are relevant for the Moonbase Alp
 | ERC721M Token (mintable on Moonbase Alpha) | {{ networks.moonbase.chainbridge.ERC721M }}        |
 
 
-All of the above addresses are valid on both Kovan and Rinkeby. You will be able to specify which network to interact with when interacting with the Bridge contract.
+All of the above addresses are valid on both Kovan and Rinkeby. You will be able to specify which network to transfer the tokens to when interacting with the Bridge contract.
 
 ### Moonbase Alpha ChainBridge UI
 

--- a/bridges/chainbridge.md
+++ b/bridges/chainbridge.md
@@ -15,7 +15,7 @@ ChainBridge is a modular, multi-directional bridge to interact with multiple net
 
 At a high-level, ChainBridge is a message-passing protocol. A set of relayers are constantly looking for events, in either side of the bridge, which trigger a set of actions. Once a triggering event is noted, a set of relayers vote to execute the instructions (included in the event) in the chain on the other side of the bridge.
 
-For example, the bridge can be used to transfer ERC-20 or ERC-721 natively. A set of handler contracts are pre-configured to handle both token standards. At its core, the token transfer mechanism works with a lock-mint, burn-unlock mechanism. First tokens are locked in the source chain, and an event is emitted, which is listened to by the relayers. Then, they vote and (if approved) execute the mint function, giving the same amount of tokens locked in the target chain to the corresponding address.
+For example, the bridge can be used to transfer ERC-20 or ERC-721 natively . A set of handler contracts are pre-configured to handle both token standards. At its core, the token transfer mechanism works with a lock-mint, burn-unlock mechanism. First tokens are locked in the source chain, and an event is emitted, which is listened to by the relayers. Then, they vote and (if approved) execute the mint function, giving the same amount of tokens locked in the target chain to the corresponding address.
 
 You can read more about ChainBridge (and ChainSafe) in the following links:
 
@@ -36,30 +36,19 @@ ChainBridge is currently connecting the Moonbase Alpha TestNet with both Kovan a
 
 ### Moonbase Alpha - Rinkeby
 
-You can find all the contract's addresses that are relevant for the Moonbase Alpha - Rinkeby bridge in the following table:
+You can find all the contract's addresses that are relevant for the Moonbase Alpha - Kovan/Rinkeby bridge in the following table:
 
-|                  Contract                  |                          Address                           |
-| :----------------------------------------: | :--------------------------------------------------------: |
-|                   Bridge                   | {{ networks.moonbase.chainbridge.rinkeby.bridge_address }} |
-|               ERC20 Handler                | {{ networks.moonbase.chainbridge.rinkeby.ERC20_handler }}  |
-|               ERC721 Handler               | {{ networks.moonbase.chainbridge.rinkeby.ERC721_handler }} |
-|                ERC20S Token                |     {{ networks.moonbase.chainbridge.rinkeby.ERC20S }}     |
-| ERC721M Token (mintable on Moonbase Alpha) |    {{ networks.moonbase.chainbridge.rinkeby.ERC721M }}     |
-|    ERC721E Token (mintable on Rinkeby)     |    {{ networks.moonbase.chainbridge.rinkeby.ERC721E }}     |
+|                  Contract                  |                          Address                   |
+| :----------------------------------------: | :------------------------------------------------: |
+|                   Bridge                   | {{ networks.moonbase.chainbridge.bridge_address }} |
+|               ERC20 Handler                | {{ networks.moonbase.chainbridge.ERC20_handler }}  |
+|               ERC721 Handler               | {{ networks.moonbase.chainbridge.ERC721_handler }} |
+|                ERC20S Token                | {{ networks.moonbase.chainbridge.ERC20S }}         |
+| ERC721M Token (mintable on Moonbase Alpha) | {{ networks.moonbase.chainbridge.ERC721M }}        |
 
-### Moonbase Alpha - Kovan
 
-You can find all the contract's addresses that are relevant for the Moonbase Alpha - Kovan bridge in the following table:
+All of the above addresses are valid on both Kovan and Rinkeby. You will be able to specify which network to interact with when interacting with the Bridge contract.
 
-|                  Contract                  |                         Address                          |
-| :----------------------------------------: | :------------------------------------------------------: |
-|                   Bridge                   | {{ networks.moonbase.chainbridge.kovan.bridge_address }} |
-|               ERC20 Handler                | {{ networks.moonbase.chainbridge.kovan.ERC20_handler }}  |
-|               ERC721 Handler               | {{ networks.moonbase.chainbridge.kovan.ERC721_handler }} |
-|                ERC20S Token                |     {{ networks.moonbase.chainbridge.kovan.ERC20S }}     |
-| ERC721M Token (mintable on Moonbase Alpha) |    {{ networks.moonbase.chainbridge.kovan.ERC721M }}     |
-|     ERC721E Token (mintable on Kovan)      |    {{ networks.moonbase.chainbridge.kovan.ERC721E }}     |
+### Moonbase Alpha ChainBridge UI
 
-### ChainBridge UI
-
-Currently, there is a UI available for ChainBridge. You can find the related repository [here](https://github.com/ChainSafe/chainbridge-ui)
+If you want to play around with transferring ERC20S tokens from Moonbase Alpha to Kovan or Rinkeby without having to set up the contracts in Remix, you can checkout the [Moonbase Alpha ChainBridge UI](https://moonbase-chainbridge.netlify.app/).


### PR DESCRIPTION
I didn't realize we had another chainbridge documentation section, so just updating this one to be consistent with the changes made in Integrations > Bridges > Ethereum > ChainBridge section 