### PR TITLE
Fix/arrange to nav

### DIFF
--- a/.pages
+++ b/.pages
@@ -2,3 +2,8 @@ title: DApps List
 hide: false
 nav:
   - README.md
+  - template.md
+  - bridges
+  - defi
+  - metaTransactions
+  - oracles

--- a/.pages
+++ b/.pages
@@ -1,4 +1,4 @@
 title: DApps List
 hide: false
-arrange:
+nav:
   - README.md

--- a/apis/.pages
+++ b/apis/.pages
@@ -1,2 +1,2 @@
 title: APIs
-arrange:
+nav:

--- a/assets/.pages
+++ b/assets/.pages
@@ -1,3 +1,3 @@
 title: Assets & Issuance
-arrange:
+nav:
   

--- a/bridges/.pages
+++ b/bridges/.pages
@@ -1,3 +1,3 @@
 title: Bridges
-arrange:
+nav:
   

--- a/defi/.pages
+++ b/defi/.pages
@@ -1,3 +1,3 @@
 title: DeFi
-arrange:
+nav:
   

--- a/explorers/.pages
+++ b/explorers/.pages
@@ -1,2 +1,2 @@
 title: Explorers
-arrange:
+nav:

--- a/marketplaces/.pages
+++ b/marketplaces/.pages
@@ -1,2 +1,2 @@
 title: Marketplaces
-arrange:
+nav:

--- a/metaTransactions/.pages
+++ b/metaTransactions/.pages
@@ -1,2 +1,2 @@
 title: MetaTransactions
-arrange:
+nav:

--- a/oracles/.pages
+++ b/oracles/.pages
@@ -1,2 +1,2 @@
 title: Oracles
-arrange:
+nav:

--- a/wallets/.pages
+++ b/wallets/.pages
@@ -1,3 +1,3 @@
 title: Wallets
-arrange:
+nav:
   - example.md


### PR DESCRIPTION
`arrange` has been deprecated, replace with `nav` and fill out the root `.pages` file with the structure of the dapps list

- no review is needed