### PR TITLE
update erc-* and dapp for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ---
 title: Listing your Project
-description: How you can list your TestNet project or dApp on the Moonbeam documentation site
+description: How you can list your TestNet project or DApp on the Moonbeam documentation site
 ---
 
-# How to List your Project/dApp
+# How to List your Project/DApp
  
 ![Template banner image](images/list-dapps-banner.png)
 
@@ -11,17 +11,17 @@ description: How you can list your TestNet project or dApp on the Moonbeam docum
 
 ## Minimum Content
 
-In general, to be considered and added to this list, your project/dApp must meet the following requirements in terms of content:
+In general, to be considered and added to this list, your project/DApp must meet the following requirements in terms of content:
 
  - Introduction (see template file)
  - Show working contracts and/or front-ends deployed or connected to the Moonbase Alpha TestNet
- - Explain to users how they can test or integrate your project/dApp
+ - Explain to users how they can test or integrate your project/DApp
  - Link the GitHub repos of the code
  - Link to communication channels
 
 ## Getting Started
 
-This guide will help you get started on listing your project/dApp in the Moonbeam docs site.
+This guide will help you get started on listing your project/DApp in the Moonbeam docs site.
 
 ### Forking/Cloning the Repo
 

--- a/bridges/eth/chainbridge.md
+++ b/bridges/eth/chainbridge.md
@@ -38,13 +38,13 @@ ChainBridge is currently connecting the Moonbase Alpha TestNet with both Kovan a
 
 You can find all the contract's addresses that are relevant for the Moonbase Alpha - Kovan/Rinkeby bridge in the following table:
 
-|                  Contract                  |                          Address                   |
-| :----------------------------------------: | :------------------------------------------------: |
+|                  Contract                  |                      Address                       |
+|:------------------------------------------:|:--------------------------------------------------:|
 |                   Bridge                   | {{ networks.moonbase.chainbridge.bridge_address }} |
-|               ERC20 Handler                | {{ networks.moonbase.chainbridge.ERC20_handler }}  |
-|               ERC721 Handler               | {{ networks.moonbase.chainbridge.ERC721_handler }} |
-|                ERC20S Token                | {{ networks.moonbase.chainbridge.ERC20S }}         |
-| ERC721M Token (mintable on Moonbase Alpha) | {{ networks.moonbase.chainbridge.ERC721M }}        |
+|               ERC-20 Handler               | {{ networks.moonbase.chainbridge.ERC20_handler }}  |
+|              ERC-721 Handler               | {{ networks.moonbase.chainbridge.ERC721_handler }} |
+|                ERC20S Token                |     {{ networks.moonbase.chainbridge.ERC20S }}     |
+| ERC721M Token (mintable on Moonbase Alpha) |    {{ networks.moonbase.chainbridge.ERC721M }}     |
 
 
 All of the above addresses are valid on both Kovan and Rinkeby. You will be able to specify which network to transfer the tokens to when interacting with the Bridge contract.

--- a/list-your-project.md
+++ b/list-your-project.md
@@ -1,9 +1,9 @@
 ---
 title: List your Project
-description: How you can list your TestNet project or dApp on the Moonbeam documentation site
+description: How you can list your TestNet project or DApp on the Moonbeam documentation site
 ---
 
-# How to List your Project/dApp
+# How to List your Project/DApp
  
 ![Template banner image](images/list-dapps-banner.png)
 
@@ -11,17 +11,17 @@ description: How you can list your TestNet project or dApp on the Moonbeam docum
 
 ## Minimum Content
 
-In general, to be considered and added to this list, your project/dApp must meet the following requirements in terms of content:
+In general, to be considered and added to this list, your project/DApp must meet the following requirements in terms of content:
 
  - Introduction (see template file)
  - Show working contracts and/or front-ends deployed or connected to the Moonbase Alpha TestNet
- - Explain to users how they can test or integrate your project/dApp
+ - Explain to users how they can test or integrate your project/DApp
  - Link the GitHub repos of the code
  - Link to communication channels
 
 ## Getting Started
 
-This guide will help you get started on listing your project/dApp in the Moonbeam docs site.
+This guide will help you get started on listing your project/DApp in the Moonbeam docs site.
 
 ### Forking/Cloning the Repo
 

--- a/metaTransactions/biconomy.md
+++ b/metaTransactions/biconomy.md
@@ -102,7 +102,7 @@ Follow the steps **[here](https://docs.biconomy.io/biconomy-dashboard)**, to re
 
 ## Learn More
 
-Wanna make your users pay gas-fee in ERC20 tokens? We can help you with that. Read more about that on our [docs](http://docs.biconomy.io).
+Wanna make your users pay gas-fee in ERC-20 tokens? We can help you with that. Read more about that on our [docs](http://docs.biconomy.io).
 
 ## Wanna get in touch?
 

--- a/metaTransactions/biconomy.md
+++ b/metaTransactions/biconomy.md
@@ -13,10 +13,10 @@ description: A scalable relayer infrastructure for transactions that can be used
 
 ## Introduction
 
-Biconomy is a scalable transaction relayer infrastructure, which can pay blockchain transaction's gas fee for your dApp user, while collecting fees from you on monthly basis, in form of some stable token.
+Biconomy is a scalable transaction relayer infrastructure, which can pay blockchain transaction's gas fee for your DApp user, while collecting fees from you on monthly basis, in form of some stable token.
 
-- **Dapps require way too much onboarding and are too hard to even begin using. We need a solution to make onboarding easy for users.** Non-crypto savvy new users will have to pass KYC, purchase ETH from an exchange, download a wallet, then connect their wallet before they can go any further, which can take days! No one waits for days to try out an application.
-- **One of the major issues is need to hold Native currency for using dapps. Users can only pay in ETH**, which they may not have at that moment. Or the user may not want to spend their ETH investment.
+- **DApps require way too much onboarding and are too hard to even begin using. We need a solution to make onboarding easy for users.** Non-crypto savvy new users will have to pass KYC, purchase ETH from an exchange, download a wallet, then connect their wallet before they can go any further, which can take days! No one waits for days to try out an application.
+- **One of the major issues is need to hold Native currency for using DApps. Users can only pay in ETH**, which they may not have at that moment. Or the user may not want to spend their ETH investment.
 - **The necessity to pay a gas** fee every time the user uses your application. Netflix does not charge you their AWS fees for every time you watch a video, so why should Dapps charge you gas fees for every interaction you do?
 - **Proficiency in complex blockchain technicalities is required** such as using MetaMask, signing transactions, understanding gas etc. If the project is on layer 2, they need to know what that really means and be able to change RPC manually.
 - **Volatile and high gas fees** further dampen the user experience on your Dapp.
@@ -40,7 +40,7 @@ Biconomy supports Gnosis contract wallet integration. Checkout how you can integ
 
 ### 2. Custom Implementation
 
-If dApps support native meta transactions, then Biconomy's relayers would directly relay the transactions to the network without the need for any proxy contract.
+If DApps support native meta transactions, then Biconomy's relayers would directly relay the transactions to the network without the need for any proxy contract.
 
 ![../images/biconomy/native-meta-tx.png](../images/biconomy/native-meta-tx.png)
 
@@ -84,7 +84,7 @@ Follow the steps **[here](https://docs.biconomy.io/biconomy-dashboard)**, to re
 
    biconomy.onEvent(biconomy.READY, () => {
 
-     // Initialize your dapp here like getting user accounts, initialising contracts and etc
+     // Initialize your DApp here like getting user accounts, initialising contracts and etc
 
    }).onEvent(biconomy.ERROR, (error, message) => {
 
@@ -93,7 +93,7 @@ Follow the steps **[here](https://docs.biconomy.io/biconomy-dashboard)**, to re
    });
    ```
 
-🥳 Congrats, you've successfully integrated Biconomy into your Dapp and now your dapp supports meta Tx.
+🥳 Congrats, you've successfully integrated Biconomy into your DApp and now your DApp supports meta Tx.
 
 ## You can checkout more in following links.
 

--- a/oracles/dia.md
+++ b/oracles/dia.md
@@ -1,6 +1,6 @@
 ---
 title: DIA Data
-description: How to use request data from a DIA Oracle in your Moonbeam Ethereum Dapp using smart contracts
+description: How to use request data from a DIA Oracle in your Moonbeam Ethereum DApp using smart contracts
 ---
 
 # DIA Data Oracles on Moonbeam
@@ -13,7 +13,7 @@ description: How to use request data from a DIA Oracle in your Moonbeam Ethereum
 
 DIA is an ecosystem for open financial data in a financial smart contract ecosystem.
 The target of DIA is to bring together data analysts, data providers and data users.
-In general, DIA provides a reliable and verifiable bridge between off-chain data from various sources and on-chain smart contracts that can be used to build a variety of financial dApps. 
+In general, DIA provides a reliable and verifiable bridge between off-chain data from various sources and on-chain smart contracts that can be used to build a variety of financial DApps. 
 DApp developers who want to leverage DIA oracles can access the published data on Moonbeam.
 DIA offers data about traditional financial assets and cryptocurrencies.
 [Read our documentation](https://docs.diadata.org) to learn about our methodologies, API, oracles, and how to contribute.

--- a/template.md
+++ b/template.md
@@ -1,9 +1,9 @@
 ---
 title: Template
-description: Template to list your TestNet project or dApp in the Moonbeam documentation site
+description: Template to list your TestNet project or DApp in the Moonbeam documentation site
 ---
 
-# Title of Project/dApp with TitleCase
+# Title of Project/DApp with TitleCase
 
 ![Template banner image](./images/template-banner.png)
 
@@ -13,7 +13,7 @@ description: Template to list your TestNet project or dApp in the Moonbeam docum
 
 This file outlines a template that should be followed when listing projects in this directory. 
 
-This first section should be an introduction to your project/dApp. You may include:
+This first section should be an introduction to your project/DApp. You may include:
 
  - High-level explanation of what does it do?
  - What value it brings to the user
@@ -25,11 +25,11 @@ This section covers the minimum content necessary to be listed and the structure
 
 ### Minimum Content
 
-In general, to be considered and added to this list, your project/dApp must meet the following requirements in terms of content:
+In general, to be considered and added to this list, your project/DApp must meet the following requirements in terms of content:
 
  - Introduction (see the "Introduction" section)
  - Show working contracts and/or front-ends deployed or connected to the Moonbase Alpha TestNet
- - Explain to users how they can test or integrate your project/dApp
+ - Explain to users how they can test or integrate your project/DApp
  - Link the GitHub repos of the code
  - Link to communication channels
 
@@ -132,7 +132,7 @@ Some key takeaways:
 
 ### Images
 
-Before you add images to your documentation, please first create a directory (with a name related to your project/dApp) inside the `images` folder. 
+Before you add images to your documentation, please first create a directory (with a name related to your project/DApp) inside the `images` folder. 
 
 With the folder created, you can add images to your documentation page using the following structure:
 


### PR DESCRIPTION
There are places where ERC20 and ERC-20 are used, so changed all references from ERC* to ERC-*

Noticed when I went to go update the Moonbeam Docs Standards that we also should be using DApps instead of dApps, so updated that too!